### PR TITLE
Installer dependencies, change user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV SONAR_SCANNER_VERSION="3.2.0.1227"
 ENV DEPENDENCY_CHECK_VERSION="3.3.4"
 
 RUN apt-get -y update \
-    && apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common \
+    && apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common build-essential \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" \
     && apt-get -y update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/jnlp-slave:3.19-1
 
 ARG DOCKER_GID=497
 
-USER root
+USER jenkins
 
 ENV DOCKER_VERSION "18.03.1-ce"
 ENV SONAR_SCANNER_VERSION="3.2.0.1227"


### PR DESCRIPTION
- Don't use root
- include `build-essential` for native builds (`g++`, etc)

`jenkins` is the default user for the jenkins docker slave:
https://github.com/jenkinsci/docker-slave/blob/master/Dockerfile#L27