### PR TITLE
Remove Helm Init

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,4 @@
 set -e
 
 exec /usr/bin/mongod &
-exec /usr/local/bin/helm init --client-only
 exec /usr/local/bin/jenkins-slave "$@"


### PR DESCRIPTION
the helm init command should be executed at runtime, not at container startup.